### PR TITLE
Improve iOS clipboard auto read

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,24 +83,34 @@ export default function App () {
 
   const isValid = errors.length === 0 && rows.length > 0;
 
-  /* 2-5-b. 最初のタップで自動読込 */
+  /* 2-5-b. 最初のタップで自動読込 (iOS 対応) */
   useEffect(() => {
-    function handleFirstPointer () {
+    function handleFirstInteraction () {
       if (!needsAutoRead.current) return;
       needsAutoRead.current = false;
-      document.body.removeEventListener('pointerdown', handleFirstPointer);
+      removeListeners();
       autoReadClipboard();
     }
-    document.body.addEventListener('pointerdown', handleFirstPointer, { once: true });
 
-    return () => {
-      document.body.removeEventListener('pointerdown', handleFirstPointer);
-    };
+    function removeListeners () {
+      document.body.removeEventListener('pointerdown', handleFirstInteraction);
+      document.body.removeEventListener('touchstart', handleFirstInteraction);
+      document.body.removeEventListener('mousedown', handleFirstInteraction);
+    }
+
+    document.body.addEventListener('pointerdown', handleFirstInteraction, { once: true });
+    document.body.addEventListener('touchstart', handleFirstInteraction, { once: true });
+    document.body.addEventListener('mousedown', handleFirstInteraction, { once: true });
+
+    return removeListeners;
   }, []);
 
   /* 自動クリップボード読込本体 */
   async function autoReadClipboard () {
     try {
+      if (!(navigator.clipboard && navigator.clipboard.readText)) {
+        throw new Error('Clipboard API not supported');
+      }
       const txt = await navigator.clipboard.readText();
       if (txt.trim().startsWith('[')) {
         parseJson(txt);


### PR DESCRIPTION
## Summary
- auto read clipboard via touchstart/mousedown events to support iPhone
- guard auto clipboard read when Clipboard API is missing

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_687c17fe28508326810f7ad4492f593a