### PR TITLE
Enhance location parsing

### DIFF
--- a/src/utils/parsers.js
+++ b/src/utils/parsers.js
@@ -5,8 +5,13 @@ export function classifyTag (desc) {
     return /遠隔授業/.test(desc) ? 'オンデマ' : '対面';
   }
   
-  /* DESCRIPTION から「○○室」パターンを抽出 */
-  export function extractLocation (desc) {
-    const m = desc.match(/\/\s*([^/]*?室)\s*\//)
-    return m ? m[1] : ''
-  }
+/* DESCRIPTION から場所を抽出 */
+export function extractLocation(desc) {
+  // 教員名 "(○○)" の後ろを優先的に拾う
+  let m = desc.match(/\/\s*\([^/]*\)\s*\/\s*([^/]+?)(?:\s*\/|$)/);
+  if (m) return m[1].trim();
+
+  // 従来どおり「○○室」パターンも許可 (末尾に英字が付く場合も考慮)
+  m = desc.match(/\/\s*([^/]*?室[^/]*)\s*(?:\/|$)/);
+  return m ? m[1].trim() : '';
+}


### PR DESCRIPTION
## Summary
- improve location extraction to catch descriptions where the room isn't just `○○室`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_687c1d84b0588326a00101f08a55a642