### PR TITLE
Add NDJSON support for event input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ iOS ショートカットで抽出した **イベント JSON** から
 | LOCATION 抽出 | `/ ○○室 /` パターンを正規表現で抜き出し |
 | DESCRIPTION 保持 | 改行をそのままエスケープして ICS の `DESCRIPTION` に反映 |
 | 完全 Frontend | **ics-js** を用いてクライアント側で .ics テキストを生成 → Blob → ダウンロード |
+| NDJSON 対応 | 行ごとに JSON を並べた形式 (NDJSON) も解析可能 |
 
 ## 使い方
 1. iOS ショートカットを実行し、イベント JSON をクリップボードへコピー
@@ -23,3 +24,4 @@ iOS ショートカットで抽出した **イベント JSON** から
 npm i          # 依存解決
 npm run dev    # ローカルサーバ
 npm run build  # 本番ビルド (dist/)
+```

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,9 +30,22 @@ export default function App () {
   /* 2-3. JSON 解析 */
   function parseJson (text, showAlert = true) {
     try {
+      let arr;
       // 先頭/末尾のゴミ除去
-      const cleaned = text.trim().replace(/^[^\[]*/, '').replace(/[^\]]*$/, '');
-      const arr = JSON.parse(cleaned);
+      const cleaned = text.trim();
+
+      try {
+        const slice = cleaned.replace(/^[^\[]*/, '').replace(/[^\]]*$/, '');
+        const parsed = JSON.parse(slice);
+        arr = Array.isArray(parsed) ? parsed : [parsed];
+      } catch (e) {
+        // 改行区切りの JSON オブジェクト列に対応
+        arr = cleaned
+          .split(/\n+/)
+          .map(line => line.trim())
+          .filter(Boolean)
+          .map(line => JSON.parse(line));
+      }
 
       const mapped = arr.map(ev => {
         const tag = classifyTag(ev.description || '');


### PR DESCRIPTION
## Summary
- support newline-separated (NDJSON) event input when parsing JSON
- fix README formatting and document NDJSON support

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687c4d4e83748326aa528a1cf213fd0c