### PR TITLE
Add how-to page

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>使い方 - DreamCampus Calendar Maker</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sanitize.css" />
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body class="dc-bg" style="padding:1rem;">
+    <h1>使い方</h1>
+    <ol>
+      <li>iOSショートカットを実行して、イベントJSONをクリップボードへコピーします。</li>
+      <li>トップページでペーストボタンを押すかテキストボックスに貼り付けます。</li>
+      <li>欠落している項目を編集して<strong>ICS生成</strong>ボタンを押します。</li>
+    </ol>
+    <p><a href="https://www.icloud.com/shortcuts/b75c24fe4c9e4f2d9bcae28389a6589e">iOSショートカットはこちら</a></p>
+    <p><a href="index.html">戻る</a></p>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,6 +99,7 @@ export default function App () {
       <div className="button-row">
         <button onClick={handleReadClipboard}>ペースト</button>
         <button disabled={!isValid} onClick={handleGenerate}>ICS 生成</button>
+        <button onClick={() => { window.location.href = 'howto.html' }}>使い方</button>
       </div>
 
       <textarea


### PR DESCRIPTION
## Summary
- add a simple howto.html with basic instructions and shortcut link
- add "使い方" button in the main UI linking to the new page

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_687c66c78650832680c8ead655f24da6