### PR TITLE
Fix how-to button

### DIFF
--- a/howto.html
+++ b/howto.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>使い方 - DreamCampus Calendar Maker</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sanitize.css" />
+    <link rel="stylesheet" href="/src/index.css" />
+  </head>
+  <body class="dc-bg" style="padding:1rem;">
+    <h1>使い方</h1>
+    <ol>
+      <li>iOSショートカットを実行して、イベントJSONをクリップボードへコピーします。</li>
+      <li>トップページでペーストボタンを押すかテキストボックスに貼り付けます。</li>
+      <li>欠落している項目を編集して<strong>ICS生成</strong>ボタンを押します。</li>
+    </ol>
+    <p><a href="https://www.icloud.com/shortcuts/b75c24fe4c9e4f2d9bcae28389a6589e">iOSショートカットはこちら</a></p>
+    <p><a href="index.html">戻る</a></p>
+  </body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,6 +99,7 @@ export default function App () {
       <div className="button-row">
         <button onClick={handleReadClipboard}>ペースト</button>
         <button disabled={!isValid} onClick={handleGenerate}>ICS 生成</button>
+        <a href="howto.html" className="button-link">使い方</a>
       </div>
 
       <textarea

--- a/src/index.css
+++ b/src/index.css
@@ -54,22 +54,26 @@
   gap: 0.5rem;
   flex-wrap: wrap;
 }
-  
-  button {
-    cursor: pointer;
-    border: 1px solid var(--border);
-    background: var(--card);
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    transition: background 0.2s;
-  }
-  button:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-  }
-  button:not(:disabled):hover {
-    background: rgba(0 0 0 / 0.04);
-  }
+
+.button-row button,
+.button-row a.button-link {
+  cursor: pointer;
+  border: 1px solid var(--border);
+  background: var(--card);
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  transition: background 0.2s;
+  text-decoration: none;
+  display: inline-block;
+}
+.button-row button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.button-row button:not(:disabled):hover,
+.button-row a.button-link:hover {
+  background: rgba(0 0 0 / 0.04);
+}
   
   /* テーブル */
   table {
@@ -101,7 +105,8 @@
   h1 {
     font-size: 1.25rem;
   }
-  .button-row button {
+  .button-row button,
+  .button-row a.button-link {
     flex: 1 0 auto;
   }
 }


### PR DESCRIPTION
## Summary
- style button-row anchors like buttons
- change how-to navigation to use an `<a>` link so it works

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find module '@rollup/rollup-linux-x64-gnu')*


------
https://chatgpt.com/codex/tasks/task_e_687c66c78650832680c8ead655f24da6