### PR TITLE
Allow ICS creation without location

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -104,8 +104,17 @@ input::placeholder {
   border: 2px solid #f66 !important;
 }
 
+.warning {
+  border: 2px solid #fc6 !important;
+}
+
 .error-list {
   color: #f66;
+  margin-top: 0.5rem;
+}
+
+.warning-list {
+  color: #fc6;
   margin-top: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- show warnings separately from errors
- highlight missing face-to-face locations in yellow
- allow ICS generation even if location is absent
- keep current table rows if JSON parsing fails during manual edits

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687c741279588326b85e0abc7e1049d4