### PR TITLE
Allow ICS creation without location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ iOS ショートカットで抽出した **イベント JSON** から
 |------|------|
 | クリップボード読込 | `navigator.clipboard.readText()` 対応。テキストボックスへの貼り付けも可 |
 | 欠落補完 UI | 時刻・分類・場所が空欄ならセルを赤枠表示。全部埋めないと生成ボタン非活性 |
-| 自動分類 | `DESCRIPTION` 内のキーワードから **対面 / zoom / オンデバ** を推定 |
-| LOCATION 抽出 | `/ ○○室 /` パターンを正規表現で抜き出し |
+| 自動分類 | `DESCRIPTION` 内のキーワードから **対面 / zoom / オンデマ** を推定し、DESCRIPTION を編集すると自動で再判定 |
+| LOCATION 抽出 | `/ ○○室 /` パターンを正規表現で抜き出し、DESCRIPTION 変更時にも反映 |
 | DESCRIPTION 保持 | 改行をそのままエスケープして ICS の `DESCRIPTION` に反映 |
 | 完全 Frontend | **ics-js** を用いてクライアント側で .ics テキストを生成 → Blob → ダウンロード |
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,6 +15,7 @@ export default function App () {
   const [rows, setRows]       = useState([]);
   const [rawInput, setRawInput] = useState('');
   const [errors, setErrors]   = useState([]);
+  const [warnings, setWarnings] = useState([]);
 
   /* 2-2. クリップボード読み取りボタン */
   async function handleReadClipboard () {
@@ -50,32 +51,48 @@ export default function App () {
       });
       setRows(mapped);
       setErrors([]);
+      setWarnings([]);
     } catch (e) {
       if (showAlert) alert('JSON 解析に失敗しました');
       console.error(e);
-      if (!showAlert) setRows([]);
+      // 入力中の一時的な構文エラーではテーブルを消さない
+      if (!showAlert) return;
+      setRows([]);
     }
   }
 
   /* 2-4. 行編集ハンドラ */
   function updateRow (id, field, value) {
     setRows(prev =>
-      prev.map(r => (r.id === id ? { ...r, [field]: value } : r))
+      prev.map(r => {
+        if (r.id !== id) return r;
+        const updated = { ...r, [field]: value };
+        if (field === 'description') {
+          updated.tag = classifyTag(value);
+          updated.location = extractLocation(value);
+        }
+        return updated;
+      })
     );
   }
 
   /* 2-5. バリデーション */
   useEffect(() => {
-    const errs = rows.flatMap(r => {
-      const list = [];
-      if (!r.date) list.push('日付未入力');
-      if (!/^\d{2}:\d{2}$/.test(r.start)) list.push('開始時刻不正');
-      if (!/^\d{2}:\d{2}$/.test(r.end)) list.push('終了時刻不正');
-      if (!r.tag) list.push('分類タグ未入力');
-      if (r.tag === '対面' && !r.location) list.push('対面なのに場所が空');
-      return list.length ? { id: r.id, list } : [];
+    const errs = [];
+    const warns = [];
+    rows.forEach(r => {
+      const elist = [];
+      const wlist = [];
+      if (!r.date) elist.push('日付未入力');
+      if (!/^\d{2}:\d{2}$/.test(r.start)) elist.push('開始時刻不正');
+      if (!/^\d{2}:\d{2}$/.test(r.end)) elist.push('終了時刻不正');
+      if (!r.tag) elist.push('分類タグ未入力');
+      if (r.tag === '対面' && !r.location) wlist.push('対面なのに場所が空');
+      if (elist.length) errs.push({ id: r.id, list: elist });
+      if (wlist.length) warns.push({ id: r.id, list: wlist });
     });
     setErrors(errs);
+    setWarnings(warns);
   }, [rows]);
 
   const isValid = errors.length === 0 && rows.length > 0;
@@ -121,6 +138,17 @@ export default function App () {
         </ul>
       )}
 
+      {/* 警告一覧 */}
+      {warnings.length > 0 && (
+        <ul className="warning-list">
+          {warnings.map(wr => (
+            <li key={wr.id}>
+              行 {rows.findIndex(r => r.id === wr.id) + 1}: {wr.list.join(' / ')}
+            </li>
+          ))}
+        </ul>
+      )}
+
       {/* 編集テーブル */}
       {rows.length > 0 && (
         <table>
@@ -136,7 +164,7 @@ export default function App () {
               const invalidStart = !/^\d{2}:\d{2}$/.test(r.start);
               const invalidEnd = !/^\d{2}:\d{2}$/.test(r.end);
               const invalidTag = !r.tag;
-              const invalidLoc = r.tag === '対面' && !r.location;
+              const warnLoc = r.tag === '対面' && !r.location;
               return (
               <tr key={r.id}>
                 {/* date */}
@@ -182,7 +210,7 @@ export default function App () {
                 {/* location */}
                 <td>
                   <input value={r.location}
-                    className={invalidLoc ? 'invalid' : ''}
+                    className={warnLoc ? 'warning' : ''}
                     onChange={e => updateRow(r.id, 'location', e.target.value)} />
                 </td>
 

--- a/src/index.css
+++ b/src/index.css
@@ -104,8 +104,17 @@ input::placeholder {
   border: 2px solid #f66 !important;
 }
 
+.warning {
+  border: 2px solid #fc6 !important;
+}
+
 .error-list {
   color: #f66;
+  margin-top: 0.5rem;
+}
+
+.warning-list {
+  color: #fc6;
   margin-top: 0.5rem;
 }
 


### PR DESCRIPTION
## Summary
- show warnings separately from errors
- highlight missing face-to-face locations in yellow
- allow ICS generation even if location is absent
- keep current table rows if JSON parsing fails during manual edits
- recompute tag and location when the DESCRIPTION field is edited

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687c741279588326b85e0abc7e1049d4