### PR TITLE
Improve event table

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -131,6 +131,10 @@ input::placeholder {
     background: var(--card);
     color: var(--text);
   }
+
+  tr.new-day td {
+    border-top-width: 3px;
+  }
   th {
     background: var(--card);
     position: sticky;


### PR DESCRIPTION
## Summary
- sort rows by start date/time
- keep only one add-row button
- add per-row delete button
- show separator when date changes

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_687ca35297588326947b9396d361bb94