### PR TITLE
Improve mobile table layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -210,35 +210,35 @@ export default function App () {
               return (
               <tr key={r.id} className={isNewDay ? 'new-day' : ''}>
                 {/* date */}
-                <td>
+                <td data-label="日付">
                   <input type="date" value={r.date}
                     className={invalidDate ? 'invalid' : ''}
                     onChange={e => updateRow(r.id, 'date', e.target.value)} />
                 </td>
 
                 {/* start */}
-                <td>
+                <td data-label="開始">
                   <input type="time" value={r.start}
                     className={invalidStart ? 'invalid' : ''}
                     onChange={e => updateRow(r.id, 'start', e.target.value)} />
                 </td>
 
                 {/* end */}
-                <td>
+                <td data-label="終了">
                   <input type="time" value={r.end}
                     className={invalidEnd ? 'invalid' : ''}
                     onChange={e => updateRow(r.id, 'end', e.target.value)} />
                 </td>
 
                 {/* summary */}
-                <td>
+                <td data-label="科目">
                   <input value={r.summary}
                     className={invalidSummary ? 'invalid' : ''}
                     onChange={e => updateRow(r.id, 'summary', e.target.value)} />
                 </td>
 
                 {/* tag */}
-                <td>
+                <td data-label="分類">
                   <select value={r.tag}
                     className={warnTag ? 'warning' : ''}
                     onChange={e => updateRow(r.id, 'tag', e.target.value)}>
@@ -251,20 +251,19 @@ export default function App () {
                 </td>
 
                 {/* location */}
-                <td>
+                <td data-label="場所">
                   <input value={r.location}
                     className={warnLoc ? 'warning' : ''}
                     onChange={e => updateRow(r.id, 'location', e.target.value)} />
                 </td>
 
                 {/* description */}
-                <td>
+                <td data-label="DESCRIPTION">
                   <textarea rows={2} value={r.description}
                     className={warnDesc ? 'warning' : ''}
                     onChange={e => updateRow(r.id, 'description', e.target.value)} />
                 </td>
-
-                <td>
+                <td data-label="操作">
                   <button onClick={() => deleteRow(r.id)}>削除</button>
                 </td>
               </tr>

--- a/src/index.css
+++ b/src/index.css
@@ -141,12 +141,36 @@ input::placeholder {
     top: 0;
   }
   
-  /* スマホでは列を潰しすぎないよう水平スクロール */
+  /* スマホでは各行を縦並びレイアウトに */
   @media (max-width: 640px) {
     table {
+      width: 100%;
+    }
+    thead {
+      display: none;
+    }
+    tr {
       display: block;
-      overflow-x: auto;
-      white-space: nowrap;
+      margin-bottom: 1rem;
+      border: 1px solid var(--border);
+    }
+    td {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: none;
+      border-bottom: 1px solid var(--border);
+      padding: 0.3rem 0.4rem;
+    }
+    td:last-child {
+      border-bottom: none;
+    }
+    td::before {
+      content: attr(data-label);
+      flex-basis: 4.5rem;
+      flex-shrink: 0;
+      font-size: 0.875rem;
+      opacity: 0.7;
     }
   }
 


### PR DESCRIPTION
## Summary
- make table rows vertical on small screens
- add data-label attributes for responsive table labels

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_687ca5b0e47883268c77fbdbcf7a51eb