### PR TITLE
Add mobile tile view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -118,6 +118,14 @@ input::placeholder {
   margin-top: 0.5rem;
 }
 
+.mobile-cards {
+  display: none;
+}
+
+.desktop-only {
+  display: block;
+}
+
   /* テーブル */
   table {
     width: 100%;
@@ -141,12 +149,53 @@ input::placeholder {
     top: 0;
   }
   
-  /* スマホでは列を潰しすぎないよう水平スクロール */
+  /* スマホ向けタイル表示 */
   @media (max-width: 640px) {
-    table {
+    .desktop-table,
+    .desktop-only {
+      display: none;
+    }
+    .mobile-cards {
       display: block;
-      overflow-x: auto;
-      white-space: nowrap;
+      margin-top: 1rem;
+    }
+    .card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 0.5rem;
+    }
+    .card {
+      border: 1px solid var(--border);
+      background: var(--card);
+      padding: 0.5rem;
+      text-align: left;
+      border-radius: 4px;
+    }
+    .mobile-edit thead {
+      display: none;
+    }
+    .mobile-edit tr {
+      display: block;
+      margin-bottom: 1rem;
+      border: 1px solid var(--border);
+    }
+    .mobile-edit td {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      border: none;
+      border-bottom: 1px solid var(--border);
+      padding: 0.3rem 0.4rem;
+    }
+    .mobile-edit td:last-child {
+      border-bottom: none;
+    }
+    .mobile-edit td::before {
+      content: attr(data-label);
+      flex-basis: 4.5rem;
+      flex-shrink: 0;
+      font-size: 0.875rem;
+      opacity: 0.7;
     }
   }
 


### PR DESCRIPTION
## Summary
- show cards on small screens with edit overlay
- refactor row rendering into helper
- update CSS for tile grid and edit screen

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_687ca5b0e47883268c77fbdbcf7a51eb