### PR TITLE
Improve button layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -361,17 +361,27 @@ export default function App () {
     <div className="container">
       <h1>DreamCampus Calendar Maker</h1>
 
-      <div className="button-row action-group">
-        <button onClick={handleReadClipboard}>ペースト</button>
-        <button onClick={addRow}>追加</button>
-        <button className="primary" disabled={!isValid} onClick={handleGenerate}>ICS 生成</button>
-      </div>
-      <div className="button-row edit-group">
-        <button onClick={undo} disabled={historyIndex === 0}>戻す</button>
-        <button onClick={redo} disabled={historyIndex >= maxHistory}>進む</button>
-        <button onClick={clearAll}>クリア</button>
-        <a href="./howto.html" className="button-link">使い方</a>
-      </div>
+      {editingId === null && (
+        rows.length === 0 ? (
+          <div className="button-row action-group">
+            <button onClick={handleReadClipboard}>ペースト</button>
+            <a href="./howto.html" className="button-link">使い方</a>
+          </div>
+        ) : (
+          <>
+            <div className="button-row action-group">
+              <button onClick={addRow}>追加</button>
+              <button className="primary" disabled={!isValid} onClick={handleGenerate}>ICS 生成</button>
+            </div>
+            <div className="button-row edit-group">
+              <button onClick={undo} disabled={historyIndex === 0}>戻す</button>
+              <button onClick={redo} disabled={historyIndex >= maxHistory}>進む</button>
+              <button onClick={clearAll}>クリア</button>
+              <a href="./howto.html" className="button-link">使い方</a>
+            </div>
+          </>
+        )
+      )}
 
       <textarea
         autoFocus
@@ -445,6 +455,7 @@ export default function App () {
                 <button onClick={undo} disabled={historyIndex === 0}>戻す</button>
                 <button onClick={redo} disabled={historyIndex >= maxHistory}>進む</button>
                 <button onClick={clearAll}>クリア</button>
+                <button className="primary" disabled={!isValid} onClick={handleGenerate}>ICS 生成</button>
               </div>
             </>
           ) : (
@@ -458,12 +469,15 @@ export default function App () {
             </div>
           )}
         </div>
-        <div className="button-row desktop-only" style={{marginTop: '0.5rem'}}>
-          <button onClick={addRow}>追加</button>
-          <button onClick={undo} disabled={historyIndex === 0}>戻す</button>
-          <button onClick={redo} disabled={historyIndex >= maxHistory}>進む</button>
-          <button onClick={clearAll}>クリア</button>
-        </div>
+        {rows.length > 0 && editingId === null && (
+          <div className="button-row desktop-only" style={{marginTop: '0.5rem'}}>
+            <button onClick={addRow}>追加</button>
+            <button onClick={undo} disabled={historyIndex === 0}>戻す</button>
+            <button onClick={redo} disabled={historyIndex >= maxHistory}>進む</button>
+            <button onClick={clearAll}>クリア</button>
+            <button className="primary" disabled={!isValid} onClick={handleGenerate}>ICS 生成</button>
+          </div>
+        )}
         </>
       )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -68,6 +68,7 @@ input::placeholder {
   background: var(--card);
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  overflow: hidden;
 }
 h1 {
   margin: 0 0 1rem;
@@ -277,6 +278,10 @@ h1 {
     flex: 1 0 48%;
   }
   .button-row.action-group {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+  .button-row.edit-group {
     display: grid;
     grid-template-columns: 1fr 1fr;
   }


### PR DESCRIPTION
## Summary
- only show paste button until data is loaded
- after loading show editing tools and export button
- include ICS button in mobile/desktop action bars
- hide desktop table overflow and keep undo/redo aligned

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_687ccbdc9d48832694a0505465ac2a05