### PR TITLE
Fix naming inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DreamCampus-calendar
+# DreamCampus to Calendar
 
 iOS ショートカットで抽出した **イベント JSON** から
 ブラウザだけで一括 **.ics** ファイルを生成する React + Vite 製アプリです。

--- a/howto.html
+++ b/howto.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>使い方 - DreamCampus Calendar Maker</title>
+    <title>使い方 - DreamCampus to Calendar</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sanitize.css" />
     <link rel="stylesheet" href="/src/index.css" />
   </head>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>JSON → ICS 変換ツール</title>
+    <title>DreamCampus to Calendar</title>
 
     <!-- Vite が自動注入する CSS も考慮して最低限のリセット -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/sanitize.css" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -89,7 +89,7 @@ export default function App () {
     else if (!/^\d{2}:\d{2}$/.test(r.end)) errors.push('終了時刻形式不正');
     if (!r.summary.trim()) errors.push('科目名未入力');
     if (!r.tag) warns.push('分類タグ未入力');
-    if (!r.description.trim()) warns.push('DESCRIPTION 未入力');
+    if (!r.description.trim()) warns.push('説明未入力');
     if (r.tag === '対面' && !r.location) warns.push('対面なのに場所が空');
     return { errors, warns };
   }
@@ -329,7 +329,7 @@ export default function App () {
             className={warnLoc ? 'warning' : ''}
             onChange={e => updateRow(r.id, 'location', e.target.value)} />
         </td>
-        <td data-label="DESCRIPTION">
+        <td data-label="説明">
           <textarea rows={2} value={r.description}
             className={warnDesc ? 'warning' : ''}
             onChange={e => updateRow(r.id, 'description', e.target.value)} />
@@ -345,7 +345,7 @@ export default function App () {
   return (
     <>
     <div className="container">
-      <h1>DreamCampus Calendar Maker</h1>
+      <h1>DreamCampus to Calendar</h1>
 
       {editingId === null && (
         rows.length === 0 ? (
@@ -408,7 +408,7 @@ export default function App () {
           <thead>
             <tr>
               <th>日付</th><th>開始</th><th>終了</th><th>科目</th>
-              <th>分類</th><th>場所</th><th>DESCRIPTION</th><th></th>
+              <th>分類</th><th>場所</th><th>説明</th><th></th>
             </tr>
           </thead>
           <tbody>

--- a/src/utils/icsHelpers.js
+++ b/src/utils/icsHelpers.js
@@ -23,8 +23,8 @@ export function buildICS(rows) {
       categories : tag ? [tag] : undefined,
       start      : [y,m,d,sh,sm],
       end        : [y,m,d,eh,em],
-      uid        : `${r.id}@dreamcampus`,
-      productId  : "-//DreamCampus//Calendar//JP",
+      uid        : `${r.id}@dreamcampus-to-calendar`,
+      productId  : "-//DreamCampus to Calendar//JP",
       created     : ts,              // ✅ 配列形式
       lastModified: ts               // ✅ 正しいキー名
     };


### PR DESCRIPTION
## Summary
- rename app to "DreamCampus to Calendar" across pages and README
- label DESCRIPTION column in Japanese
- update ICS product id

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_687cd87ab5708326820c4d9c672e4c62