### PR TITLE
Fix on-demand class detection

### DIFF
--- a/src/utils/parsers.js
+++ b/src/utils/parsers.js
@@ -1,9 +1,10 @@
 /* DESCRIPTION から分類タグ推定 */
 export function classifyTag (desc) {
     if (!desc) return '';
-    if (/非同期/.test(desc)) return 'オンデマ';
-    if (/遠隔授業.*同期/.test(desc) || /Zoom/i.test(desc)) return 'zoom';
-    return /遠隔授業/.test(desc) ? 'オンデマ' : '対面';
+    const normalized = desc.normalize('NFKC');
+    if (/オンデマ/.test(normalized) || /非同期/.test(normalized)) return 'オンデマ';
+    if (/遠隔授業.*同期/.test(normalized) || /Zoom/i.test(normalized)) return 'zoom';
+    return /遠隔授業/.test(normalized) ? 'オンデマ' : '対面';
   }
   
 /* DESCRIPTION から場所を抽出 */


### PR DESCRIPTION
## Summary
- Normalize class descriptions before classification
- Detect half-width kana on-demand labels as オンデマ

## Verification
- Directly checked classifyTag maps ｵﾝﾃﾞﾏﾝﾄﾞ to オンデマ
- git diff --check